### PR TITLE
handle nil youtube video statistics attribute gracefully

### DIFF
--- a/lib/active_public_resources/drivers/youtube.rb
+++ b/lib/active_public_resources/drivers/youtube.rb
@@ -120,7 +120,7 @@ module ActivePublicResources
       def parse_video(item)
         video_id = item['id']
         snippet = item['snippet']
-        statistics = item['statistics']
+        statistics = item['statistics'] ? item['statistics'] : {}
         details = item['contentDetails']
         video = APR::ResponseTypes::Video.new
         video.id             = video_id

--- a/lib/active_public_resources/version.rb
+++ b/lib/active_public_resources/version.rb
@@ -1,3 +1,3 @@
 module ActivePublicResources
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
fixes PLAT-2498

test plan:
• Install Youtube LTI
• Create a wiki page in a course
• Click the Youtube button to embed a video
• Search a topic that will return several results
• Scroll to the bottom of those results and click "load more results"