### PR TITLE
add channel_name param for next criteria fetch

### DIFF
--- a/lib/active_public_resources/drivers/youtube.rb
+++ b/lib/active_public_resources/drivers/youtube.rb
@@ -110,6 +110,7 @@ module ActivePublicResources
       def next_criteria(request_criteria, results)
         if results['nextPageToken']
           return RequestCriteria.new({
+            channel_name: request_criteria.channel_name,
             query: request_criteria.query,
             page: results['nextPageToken'],
             per_page: results['pageInfo']['resultsPerPage'].to_i

--- a/lib/active_public_resources/version.rb
+++ b/lib/active_public_resources/version.rb
@@ -1,3 +1,3 @@
 module ActivePublicResources
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end


### PR DESCRIPTION
fixes PLAT-3105

test plan:
 * add YouTube lti app via:
    https://staging.edu-apps.org/lti_public_resources/config.xml?id=youtube
 * edit the app; add the following variable under Custom Fields
    `channel_name=Playstation Access`
 * save and launch the YouTube app via RCE
 * search for "Top 10"
 * verify all the results are scoped to the channel name set
 * scroll down and select "load more results"
 * verify the newly populated results are _still_ scoped
   to the channel name that was set prior