### PR TITLE
Upgrade httparty to 0.24.0 to fix SSRF vulnrblty

### DIFF
--- a/active_public_resources.gemspec
+++ b/active_public_resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.0.0"
   spec.add_dependency "activemodel", ">= 4.0.0"
   spec.add_dependency "iso8601", "~> 0.8.6"
-  spec.add_dependency "httparty", "~> 0.15.6"
+  spec.add_dependency "httparty", "~> 0.24.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
 end

--- a/lib/active_public_resources/version.rb
+++ b/lib/active_public_resources/version.rb
@@ -1,3 +1,3 @@
 module ActivePublicResources
-  VERSION = "0.2.9"
+  VERSION = "0.2.10"
 end


### PR DESCRIPTION
- Update httparty dependency from ~> 0.15.6 to ~> 0.24.0
- Fix SSRF vulnerability (SNYK-RUBY-HTTPARTY-14563114)
- Bump version to 0.2.10
- Update bundler dependency constraint to >= 1.3 for modern bundler compatibility

The SSRF fix prevents absolute URLs from bypassing base_uri configuration. This vulnerability does not affect our codebase as we don't use base_uri, but upgrading ensures we have the latest security patches.